### PR TITLE
Doc(v0.6.0): Including v1/get_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] --13.06.2025
+Backend version : version > 0.6.0 
+### Added 
+Information about additional REST endpoint : /v1/get_info
+### Changed 
+- version number to v1.2.0 
+### Removed 
 
 ## [1.1.0] -- 04.06.2025
-Backend version : Version > 0.5.1 
+Backend version : version > 0.5.1 
 ### Added 
 A CHANGELOG.md 
 ### Changed 
@@ -16,7 +23,7 @@ A CHANGELOG.md
 
 ## [1.0.0] -- 04.06.2025
 
-Backend version : 0.5.1 > Version >= v0.4.0 
+Backend version : 0.5.1 > version >= v0.4.0 
 ### Added 
 - An english version of the openAPI description 
 - The backend version to which this description corresponds to v0.4.0 

--- a/openAPIv1.2.0.json
+++ b/openAPIv1.2.0.json
@@ -1,0 +1,294 @@
+asyncapi: 3.0.0
+id: 'urn:com:example:devicesamplingapi'
+info:
+  title: Async API description of OmnAIScope DataServer
+  version: 1.0.0
+  description: |
+    This interface description documents the interface to the OmnAIScope-Backend v0.6.0> : https://github.com/AI-Gruppe/OmnAIScope-DataServer/releases/tag/v0.4.0 . 
+    The interface consists of a REST API endpoint and a WebSocket connection.
+    A data source has one or more data streams, each data stream has a UUID and a color.
+    The port on which the websocket runs is set by the client. The port number belongs to the parameters that 
+    are set when starting the backend via .\<exe> -w -p <portnumber> . 
+    
+    1. **Data Source List (HTTP GET)**
+       - **URL:** `http://<ip>:8080/UUID`
+       - **Description:** Returns a list of available data streams (UUIDs) and associated colors in JSON format.
+    2. **Data Source Information (HTTP GET)**
+       - **URL:** `http://<ip>:8080/v1/get_info`
+       - **Description:** Returns a list of available data streams (UUIDs), associated colors, the firmware and hardware version 
+       of the connected device, as well as the offset and scale of the calibration in JSON format.
+
+    3. **WebSocket Connection (Bidirectional)**
+       - **URL:** `ws://<ip>:8080/ws`
+       - **Description:** OmnAIView can send a control command as a text message via WebSocket to define which data streams of the data source should be retrieved.
+         The command consists of:
+         - A list of UUIDs (any number, at least one), separated by spaces.
+         - Optionally, a sampling rate (integer between 1 and 100000, default: 60 Sa/s).
+         - Optionally, an output format (`json`, `csv`, or `binary`).
+         **Example:** `UUID1 UUID2 UUID3 1000 csv`
+       - **Response:** Sample data is returned as JSON, CSV, or binary messages.
+
+defaultContentType: application/json
+servers:
+  httpServer:
+    host: '<ip>:8080'
+    protocol: http
+  wsServer:
+    host: '<ip>:8080'
+    protocol: ws
+
+channels:
+  /UUID:
+    address: /UUID
+    servers:
+      - $ref: '#/servers/httpServer'
+    messages:
+      deviceListResponse:
+        contentType: application/json
+        payload:
+          type: object
+          properties:
+            Datastreams:
+              type: array
+              description: List of data streams.
+              items:
+                type: object
+                properties:
+                  UUID:
+                    type: string
+            colors:
+              type: array
+              description: List of colors.
+              items:
+                type: object
+                properties:
+                  color:
+                    type: object
+                    properties:
+                      r:
+                        type: integer
+                        example: 81
+                      g:
+                        type: integer
+                        example: 237
+                      b:
+                        type: integer
+                        example: 96
+          example:
+            datastreams:
+              - UUID: E66368254F77B524
+            colors:
+              - color:
+                  r: 81
+                  g: 237
+                  b: 96
+  /v1/get_info:
+    address: /v1/get_info
+    servers:
+      - $ref: '#/servers/httpServer'
+    messages:
+      getInfoResponse:
+        contentType: application/json
+        payload:
+          type: object
+          properties:
+            devices:
+              type: array
+              description: List of connected devices
+              items:
+                type: object
+                properties:
+                  UUID:
+                    type: string
+            colors:
+              type: array
+              description: List of colors of connected devices 
+              items:
+                type: object
+                properties:
+                  color:
+                    type: object
+                    properties:
+                      r:
+                        type: integer
+                        example: 81
+                      g:
+                        type: integer
+                        example: 237
+                      b:
+                        type: integer
+                        example: 96
+            hardwareInfo:
+              type: array
+              description: Hardwareversions of the devices
+              items:
+                type: object
+                properties:
+                  major:
+                    type: integer
+                    example: 1
+                  minor:
+                    type: integer
+                    example: 0
+                  patch:
+                    type: integer
+                    example: 0
+            firmwareInfo:
+              type: array
+              description: Firmwareversions of the devices 
+              items:
+                type: object
+                properties:
+                  major:
+                    type: integer
+                    example: 2
+                  minor:
+                    type: integer
+                    example: 1
+                  patch:
+                    type: integer
+                    example: 3
+            offset:
+              type: array
+              description: Offset values of devices
+              items:
+                type: number
+                example: 0.05
+            scale:
+              type: array
+              description: Scale values of devices 
+              items:
+                type: number
+                example: 1.25
+          example:
+            devices:
+              - UUID: E66368254F77B524
+            colors:
+              - color:
+                  r: 81
+                  g: 237
+                  b: 96
+            hardwareInfo:
+              - major: 1
+                minor: 0
+                patch: 0
+            firmwareInfo:
+              - major: 2
+                minor: 1
+                patch: 3
+            offset:
+              - 0.05
+            scale:
+              - 1.25
+  /ws:
+    address: /ws
+    servers:
+      - $ref: '#/servers/wsServer'
+    messages:
+      controlCommand:
+        $ref: '#/components/messages/ControlCommand'
+      sampleDataJson:
+        $ref: '#/components/messages/SampleDataJson'
+      sampleDataCsv:
+        $ref: '#/components/messages/SampleDataCsv'
+      sampleDataBinary:
+        $ref: '#/components/messages/SampleDataBinary'
+    bindings:
+      ws: {}
+operations:
+  getDeviceList:
+    action: receive
+    channel:
+      $ref: '#/channels/~1UUID'
+    summary: Returns the list of available data streams and their colors.
+    bindings:
+      http:
+        method: GET
+    messages:
+      - $ref: '#/channels/~1UUID/messages/deviceListResponse'
+  getInfo:
+    action: receive
+    channel:
+      $ref: '#/channels/~1v1~1get_info'
+    summary: Returns device information (incl. Hardware/Firmware, Offset, Scale).
+    bindings:
+      http:
+        method: GET
+    messages:
+      - $ref: '#/channels/~1v1~1get_info/messages/getInfoResponse'
+  startDeviceData:
+    action: send
+    channel:
+      $ref: '#/channels/~1ws'
+    summary: Defines data streams, sampling rate, and format to determine how the server responds.
+    messages: 
+      - $ref: '#/channels/~1ws/messages/controlCommand'
+  receiveSampleData:
+    action: receive
+    channel:
+      $ref: '#/channels/~1ws'
+    summary: Receives sample data in JSON, CSV, or binary format.
+    messages:
+      - $ref: '#/channels/~1ws/messages/sampleDataJson'
+      - $ref: '#/channels/~1ws/messages/sampleDataCsv'
+      - $ref: '#/channels/~1ws/messages/sampleDataBinary'
+components:
+  messages:
+    ControlCommand:
+      name: ControlCommand
+      title: Control Command
+      contentType: text/plain
+      summary: >
+        This control command is sent to the WebSocket and consists of a
+        single text string containing the following components (all separated by a space):
+          - One or more UUIDs (any number, at least one).
+          - Optional: A sampling rate (integer between 1 and 100000, default: 60 Sa/s).
+          - Optional: An output format (`json`, `csv`, or `binary`).
+      payload:
+        type: string
+        pattern: '^(?<uuids>[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*)(?:\s+(?<rate>[1-9]\d{0,4}|100000))?(?:\s+(?<format>json|csv|binary))?$'
+      examples:
+        - summary: CSV request for 1000 Sa/s
+          payload: UUID1 UUID2 UUID3 1000 csv
+    SampleDataJson:
+      name: SampleDataJson
+      title: Sample Data (JSON)
+      contentType: application/json
+      summary: Sample data in JSON format.
+      payload:
+        type: object
+        properties:
+          data:
+            type: array
+            description: List of samples.
+            items:
+              type: object
+              properties:
+                timestamp:
+                  type: number
+                  example: -0.999
+                value:
+                  type: array
+                  items:
+                    type: number
+                  example:
+                    - 0.04
+          datastreams:
+            type: array
+            description: List of device UUIDs.
+            items:
+              type: string
+    SampleDataCsv:
+      name: SampleDataCsv
+      title: Sample Data (CSV)
+      contentType: text/csv
+      summary: Sample data in CSV format.
+      payload:
+        type: string
+    SampleDataBinary:
+      name: SampleDataBinary
+      title: Sample Data (Binary)
+      contentType: application/x-protobuf
+      summary: Sample data in protobuf binary format. The syntax for protobuf was syntax = "proto3"; message Sample {double timestamp = 1; repeated double values = 2;}
+      payload:
+        type: string


### PR DESCRIPTION
With version v0.6.0 the v1/get_info endpoint was introduced.

Documented this endpoint and updated the changelog.md